### PR TITLE
Introduce repository layer for decoupling controllers

### DIFF
--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TodoApi.Controllers;
 using TodoApi.Models;
+using TodoApi.Repositories;
 
 namespace TodoApi.Tests;
 
@@ -31,7 +32,9 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoItemController(context);
+            var itemRepository = new TodoItemRepository(context);
+            var listRepository = new TodoListRepository(context);
+            var controller = new TodoItemController(itemRepository, listRepository);
 
             var result = await controller.DeleteTodoItem(1, 1);
 
@@ -47,7 +50,9 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoItemController(context);
+            var itemRepository = new TodoItemRepository(context);
+            var listRepository = new TodoListRepository(context);
+            var controller = new TodoItemController(itemRepository, listRepository);
 
             var result = await controller.DeleteTodoItem(1, 2);
 
@@ -63,7 +68,9 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoItemController(context);
+            var itemRepository = new TodoItemRepository(context);
+            var listRepository = new TodoListRepository(context);
+            var controller = new TodoItemController(itemRepository, listRepository);
 
             var payload = new Dtos.UpdateTodoItem { IsCompleted = true };
 

--- a/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TodoApi.Controllers;
 using TodoApi.Models;
+using TodoApi.Repositories;
 
 namespace TodoApi.Tests;
 
@@ -29,7 +30,8 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoListsController(context);
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
 
             var result = await controller.GetTodoLists();
 
@@ -45,7 +47,8 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoListsController(context);
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
 
             var result = await controller.GetTodoList(1);
 
@@ -61,7 +64,8 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoListsController(context);
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
 
             var result = await controller.PutTodoList(
                 3,
@@ -79,7 +83,8 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoListsController(context);
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
 
             var todoList = await context.TodoList.Where(x => x.Id == 2).FirstAsync();
             var result = await controller.PutTodoList(
@@ -98,7 +103,8 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoListsController(context);
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
 
             var result = await controller.PostTodoList(new Dtos.CreateTodoList { Name = "Task 3" });
 
@@ -114,7 +120,8 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var controller = new TodoListsController(context);
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
 
             var result = await controller.DeleteTodoList(2);
 

--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using TodoApi.Repositories;
 
 var builder = WebApplication.CreateBuilder(args);
 builder
@@ -7,6 +8,9 @@ builder
     )
     .AddEndpointsApiExplorer()
     .AddControllers();
+
+builder.Services.AddScoped<ITodoListRepository, TodoListRepository>();
+builder.Services.AddScoped<ITodoItemRepository, TodoItemRepository>();
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();

--- a/TodoApi/Repositories/ITodoItemRepository.cs
+++ b/TodoApi/Repositories/ITodoItemRepository.cs
@@ -1,0 +1,12 @@
+using TodoApi.Models;
+
+namespace TodoApi.Repositories;
+
+public interface ITodoItemRepository
+{
+    Task<IList<TodoItem>> GetByListIdAsync(long listId);
+    Task<TodoItem?> GetAsync(long listId, long id);
+    Task AddAsync(TodoItem item);
+    Task RemoveAsync(TodoItem item);
+    Task SaveChangesAsync();
+}

--- a/TodoApi/Repositories/ITodoListRepository.cs
+++ b/TodoApi/Repositories/ITodoListRepository.cs
@@ -1,0 +1,12 @@
+using TodoApi.Models;
+
+namespace TodoApi.Repositories;
+
+public interface ITodoListRepository
+{
+    Task<IList<TodoList>> GetAllAsync();
+    Task<TodoList?> GetAsync(long id);
+    Task AddAsync(TodoList list);
+    Task RemoveAsync(TodoList list);
+    Task SaveChangesAsync();
+}

--- a/TodoApi/Repositories/TodoItemRepository.cs
+++ b/TodoApi/Repositories/TodoItemRepository.cs
@@ -1,0 +1,45 @@
+using Microsoft.EntityFrameworkCore;
+using TodoApi.Models;
+
+namespace TodoApi.Repositories;
+
+public class TodoItemRepository : ITodoItemRepository
+{
+    private readonly TodoContext _context;
+
+    public TodoItemRepository(TodoContext context)
+    {
+        _context = context;
+    }
+
+    public Task<IList<TodoItem>> GetByListIdAsync(long listId)
+    {
+        return _context.TodoItems
+            .Where(i => i.TodoListId == listId)
+            .AsNoTracking()
+            .ToListAsync();
+    }
+
+    public Task<TodoItem?> GetAsync(long listId, long id)
+    {
+        return _context.TodoItems
+            .FirstOrDefaultAsync(i => i.TodoListId == listId && i.Id == id);
+    }
+
+    public async Task AddAsync(TodoItem item)
+    {
+        _context.TodoItems.Add(item);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task RemoveAsync(TodoItem item)
+    {
+        _context.TodoItems.Remove(item);
+        await _context.SaveChangesAsync();
+    }
+
+    public Task SaveChangesAsync()
+    {
+        return _context.SaveChangesAsync();
+    }
+}

--- a/TodoApi/Repositories/TodoListRepository.cs
+++ b/TodoApi/Repositories/TodoListRepository.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+using TodoApi.Models;
+
+namespace TodoApi.Repositories;
+
+public class TodoListRepository : ITodoListRepository
+{
+    private readonly TodoContext _context;
+
+    public TodoListRepository(TodoContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IList<TodoList>> GetAllAsync()
+    {
+        return await _context.TodoList.AsNoTracking().ToListAsync();
+    }
+
+    public Task<TodoList?> GetAsync(long id)
+    {
+        return _context.TodoList
+            .Include(l => l.TodoItems)
+            .FirstOrDefaultAsync(l => l.Id == id);
+    }
+
+    public async Task AddAsync(TodoList list)
+    {
+        _context.TodoList.Add(list);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task RemoveAsync(TodoList list)
+    {
+        _context.TodoList.Remove(list);
+        await _context.SaveChangesAsync();
+    }
+
+    public Task SaveChangesAsync()
+    {
+        return _context.SaveChangesAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- Add repository interfaces and implementations for todo lists and items
- Refactor controllers to consume repositories instead of directly using `TodoContext`
- Register repositories in the application's service collection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68acebccd6908328a90af0f4eb660bf1