### PR TITLE
Rename TodoItemController to TodoItemsController

### DIFF
--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -34,7 +34,7 @@ public class TodoItemsControllerTests
 
             var itemRepository = new TodoItemRepository(context);
             var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemController(itemRepository, listRepository);
+            var controller = new TodoItemsController(itemRepository, listRepository);
 
             var result = await controller.DeleteTodoItem(1, 1);
 
@@ -52,7 +52,7 @@ public class TodoItemsControllerTests
 
             var itemRepository = new TodoItemRepository(context);
             var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemController(itemRepository, listRepository);
+            var controller = new TodoItemsController(itemRepository, listRepository);
 
             var result = await controller.DeleteTodoItem(1, 2);
 
@@ -70,7 +70,7 @@ public class TodoItemsControllerTests
 
             var itemRepository = new TodoItemRepository(context);
             var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemController(itemRepository, listRepository);
+            var controller = new TodoItemsController(itemRepository, listRepository);
 
             var payload = new Dtos.UpdateTodoItem { IsCompleted = true };
 

--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -7,12 +7,12 @@ namespace TodoApi.Controllers
 {
     [Route("api/todolist/{todolistId}/todoitems")]
     [ApiController]
-    public class TodoItemController : ControllerBase
+    public class TodoItemsController : ControllerBase
     {
         private readonly ITodoItemRepository _itemRepository;
         private readonly ITodoListRepository _listRepository;
 
-        public TodoItemController(ITodoItemRepository items, ITodoListRepository lists)
+        public TodoItemsController(ITodoItemRepository items, ITodoListRepository lists)
         {
             _itemRepository = items;
             _listRepository = lists;


### PR DESCRIPTION
## Summary
- rename TodoItemController class and constructor to TodoItemsController
- update tests to use TodoItemsController

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68acfbaaff8c83288ea7ddc17b1efe20