### PR TITLE
Expose Id on TodoItemDto

### DIFF
--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
 using TodoApi.Controllers;
+using TodoApi.Dtos;
 using TodoApi.Models;
 using TodoApi.Repositories;
 
@@ -72,7 +74,7 @@ public class TodoItemsControllerTests
             var listRepository = new TodoListRepository(context);
             var controller = new TodoItemController(itemRepository, listRepository);
 
-            var payload = new Dtos.UpdateTodoItem { IsCompleted = true };
+            var payload = new UpdateTodoItem { IsCompleted = true };
 
             var result = await controller.PutTodoItem(1, 1, payload);
 
@@ -81,6 +83,65 @@ public class TodoItemsControllerTests
             Assert.NotNull(item);
             Assert.True(item.IsCompleted);
             Assert.Equal("Item 1", item.Description);
+        }
+    }
+
+    [Fact]
+    public async Task GetTodoItems_WhenListExists_ReturnsDtoWithId()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var itemRepository = new TodoItemRepository(context);
+            var listRepository = new TodoListRepository(context);
+            var controller = new TodoItemController(itemRepository, listRepository);
+
+            var result = await controller.GetTodoItems(1);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var dtos = Assert.IsAssignableFrom<IList<TodoItemDto>>(okResult.Value);
+            Assert.Collection(dtos, item => Assert.Equal(1, item.Id));
+        }
+    }
+
+    [Fact]
+    public async Task GetTodoItem_WhenItemExists_ReturnsDtoWithId()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var itemRepository = new TodoItemRepository(context);
+            var listRepository = new TodoListRepository(context);
+            var controller = new TodoItemController(itemRepository, listRepository);
+
+            var result = await controller.GetTodoItem(1, 1);
+
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var dto = Assert.IsType<TodoItemDto>(okResult.Value);
+            Assert.Equal(1, dto.Id);
+        }
+    }
+
+    [Fact]
+    public async Task PostTodoItem_WhenCalled_ReturnsDtoWithId()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var itemRepository = new TodoItemRepository(context);
+            var listRepository = new TodoListRepository(context);
+            var controller = new TodoItemController(itemRepository, listRepository);
+
+            var payload = new CreateTodoItem { Description = "Item 3", IsCompleted = false };
+
+            var result = await controller.PostTodoItem(1, payload);
+
+            var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+            var dto = Assert.IsType<TodoItemDto>(created.Value);
+            Assert.Equal(3, dto.Id);
         }
     }
 }

--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -25,6 +25,7 @@ namespace TodoApi.Controllers
             var items = await _itemRepository.GetByListIdAsync(todolistId);
             return Ok(items.Select(item => new TodoItemDto
             {
+                Id = item.Id,
                 Description = item.Description,
                 IsCompleted = item.IsCompleted
             }).ToList());
@@ -43,6 +44,7 @@ namespace TodoApi.Controllers
 
             var dto = new TodoItemDto
             {
+                Id = todoItem.Id,
                 Description = todoItem.Description,
                 IsCompleted = todoItem.IsCompleted
             };
@@ -90,6 +92,7 @@ namespace TodoApi.Controllers
 
             var dto = new TodoItemDto
             {
+                Id = todoItem.Id,
                 Description = todoItem.Description,
                 IsCompleted = todoItem.IsCompleted
             };

--- a/TodoApi/Dtos/TodoItemDto.cs
+++ b/TodoApi/Dtos/TodoItemDto.cs
@@ -2,6 +2,7 @@ namespace TodoApi.Dtos;
 
 public class TodoItemDto
 {
+    public long Id { get; set; }
     public required string Description { get; set; }
     public bool IsCompleted { get; set; }
 }


### PR DESCRIPTION
## Summary
- add Id field to TodoItemDto
- populate Id in TodoItemsController responses
- test DTO Id handling for get and post operations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acfc048060832892d10cd3495f8975