### PR TITLE
Add optional tracking for GetAsync methods

### DIFF
--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -55,7 +55,7 @@ namespace TodoApi.Controllers
         [HttpPut("{id}")]
         public async Task<ActionResult> PutTodoItem(long todolistId, long id, UpdateTodoItem payload)
         {
-            var todoItem = await _itemRepository.GetAsync(todolistId, id);
+            var todoItem = await _itemRepository.GetAsync(todolistId, id, track: true);
             if (todoItem == null)
                 return NotFound();
 
@@ -101,7 +101,7 @@ namespace TodoApi.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult> DeleteTodoItem(long todolistId, long id)
         {
-            var todoItem = await _itemRepository.GetAsync(todolistId, id);
+            var todoItem = await _itemRepository.GetAsync(todolistId, id, track: true);
 
             if (todoItem == null)
             {

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -42,7 +42,7 @@ namespace TodoApi.Controllers
         [HttpPut("{id}")]
         public async Task<ActionResult> PutTodoList(long id, UpdateTodoList payload)
         {
-            var todoList = await _repository.GetAsync(id);
+            var todoList = await _repository.GetAsync(id, track: true);
 
             if (todoList == null)
             {
@@ -71,7 +71,7 @@ namespace TodoApi.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult> DeleteTodoList(long id)
         {
-            var todoList = await _repository.GetAsync(id);
+            var todoList = await _repository.GetAsync(id, track: true);
             if (todoList == null)
             {
                 return NotFound();

--- a/TodoApi/Repositories/ITodoItemRepository.cs
+++ b/TodoApi/Repositories/ITodoItemRepository.cs
@@ -5,7 +5,7 @@ namespace TodoApi.Repositories;
 public interface ITodoItemRepository
 {
     Task<IList<TodoItem>> GetByListIdAsync(long listId);
-    Task<TodoItem?> GetAsync(long listId, long id);
+    Task<TodoItem?> GetAsync(long listId, long id, bool track = false);
     Task AddAsync(TodoItem item);
     Task RemoveAsync(TodoItem item);
     Task SaveChangesAsync();

--- a/TodoApi/Repositories/ITodoListRepository.cs
+++ b/TodoApi/Repositories/ITodoListRepository.cs
@@ -5,7 +5,7 @@ namespace TodoApi.Repositories;
 public interface ITodoListRepository
 {
     Task<IList<TodoList>> GetAllAsync();
-    Task<TodoList?> GetAsync(long id);
+    Task<TodoList?> GetAsync(long id, bool track = false);
     Task AddAsync(TodoList list);
     Task RemoveAsync(TodoList list);
     Task SaveChangesAsync();

--- a/TodoApi/Repositories/TodoItemRepository.cs
+++ b/TodoApi/Repositories/TodoItemRepository.cs
@@ -20,10 +20,14 @@ public class TodoItemRepository : ITodoItemRepository
             .ToListAsync();
     }
 
-    public async Task<TodoItem?> GetAsync(long listId, long id)
+    public Task<TodoItem?> GetAsync(long listId, long id, bool track = false)
     {
-        return await _context.TodoItems
-            .FirstOrDefaultAsync(i => i.TodoListId == listId && i.Id == id);
+        IQueryable<TodoItem> query = _context.TodoItems;
+
+        if (!track)
+            query = query.AsNoTracking();
+
+        return query.FirstOrDefaultAsync(i => i.TodoListId == listId && i.Id == id);
     }
 
     public async Task AddAsync(TodoItem item)

--- a/TodoApi/Repositories/TodoListRepository.cs
+++ b/TodoApi/Repositories/TodoListRepository.cs
@@ -17,11 +17,15 @@ public class TodoListRepository : ITodoListRepository
         return await _context.TodoList.AsNoTracking().ToListAsync();
     }
 
-    public Task<TodoList?> GetAsync(long id)
+    public Task<TodoList?> GetAsync(long id, bool track = false)
     {
-        return _context.TodoList
-            .Include(l => l.TodoItems)
-            .FirstOrDefaultAsync(l => l.Id == id);
+        IQueryable<TodoList> query = _context.TodoList
+            .Include(l => l.TodoItems);
+
+        if (!track)
+            query = query.AsNoTracking();
+
+        return query.FirstOrDefaultAsync(l => l.Id == id);
     }
 
     public async Task AddAsync(TodoList list)


### PR DESCRIPTION
## Summary
- add optional tracking to repository `GetAsync` methods
- request tracking in controllers when mutating entities

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acfcaaa5948328b8c8e5617e997772