### PR TITLE
Organize DTOs by item and list

### DIFF
--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TodoApi.Controllers;
 using TodoApi.Models;
 using TodoApi.Repositories;
+using TodoApi.Dtos.TodoItems;
 
 namespace TodoApi.Tests;
 
@@ -72,7 +73,7 @@ public class TodoItemsControllerTests
             var listRepository = new TodoListRepository(context);
             var controller = new TodoItemController(itemRepository, listRepository);
 
-            var payload = new Dtos.UpdateTodoItem { IsCompleted = true };
+            var payload = new UpdateTodoItem { IsCompleted = true };
 
             var result = await controller.PutTodoItem(1, 1, payload);
 

--- a/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TodoApi.Controllers;
 using TodoApi.Models;
 using TodoApi.Repositories;
+using TodoApi.Dtos.TodoLists;
 
 namespace TodoApi.Tests;
 
@@ -69,7 +70,7 @@ public class TodoListsControllerTests
 
             var result = await controller.PutTodoList(
                 3,
-                new Dtos.UpdateTodoList { Name = "Task 3" }
+                new UpdateTodoList { Name = "Task 3" }
             );
 
             Assert.IsType<NotFoundResult>(result);
@@ -89,7 +90,7 @@ public class TodoListsControllerTests
             var todoList = await context.TodoList.Where(x => x.Id == 2).FirstAsync();
             var result = await controller.PutTodoList(
                 todoList.Id,
-                new Dtos.UpdateTodoList { Name = "Changed Task 2" }
+                new UpdateTodoList { Name = "Changed Task 2" }
             );
 
             Assert.IsType<OkObjectResult>(result);
@@ -106,7 +107,7 @@ public class TodoListsControllerTests
             var repository = new TodoListRepository(context);
             var controller = new TodoListsController(repository);
 
-            var result = await controller.PostTodoList(new Dtos.CreateTodoList { Name = "Task 3" });
+            var result = await controller.PostTodoList(new CreateTodoList { Name = "Task 3" });
 
             Assert.IsType<CreatedAtActionResult>(result.Result);
             Assert.Equal(3, context.TodoList.Count());

--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using TodoApi.Dtos;
+using TodoApi.Dtos.TodoItems;
 using TodoApi.Models;
 using TodoApi.Repositories;
 

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using TodoApi.Dtos;
+using TodoApi.Dtos.TodoLists;
 using TodoApi.Models;
 using TodoApi.Repositories;
 

--- a/TodoApi/Dtos/TodoItems/CreateTodoItem.cs
+++ b/TodoApi/Dtos/TodoItems/CreateTodoItem.cs
@@ -1,6 +1,6 @@
-namespace TodoApi.Dtos;
+namespace TodoApi.Dtos.TodoItems;
 
-public class TodoItemDto
+public class CreateTodoItem
 {
     public required string Description { get; set; }
     public bool IsCompleted { get; set; }

--- a/TodoApi/Dtos/TodoItems/TodoItemDto.cs
+++ b/TodoApi/Dtos/TodoItems/TodoItemDto.cs
@@ -1,6 +1,6 @@
-namespace TodoApi.Dtos;
+namespace TodoApi.Dtos.TodoItems;
 
-public class CreateTodoItem
+public class TodoItemDto
 {
     public required string Description { get; set; }
     public bool IsCompleted { get; set; }

--- a/TodoApi/Dtos/TodoItems/UpdateTodoItem.cs
+++ b/TodoApi/Dtos/TodoItems/UpdateTodoItem.cs
@@ -1,4 +1,4 @@
-namespace TodoApi.Dtos;
+namespace TodoApi.Dtos.TodoItems;
 
 public class UpdateTodoItem
 {

--- a/TodoApi/Dtos/TodoLists/CreateTodoList.cs
+++ b/TodoApi/Dtos/TodoLists/CreateTodoList.cs
@@ -1,4 +1,4 @@
-namespace TodoApi.Dtos;
+namespace TodoApi.Dtos.TodoLists;
 
 public class CreateTodoList
 {

--- a/TodoApi/Dtos/TodoLists/UpdateTodoList.cs
+++ b/TodoApi/Dtos/TodoLists/UpdateTodoList.cs
@@ -1,4 +1,4 @@
-namespace TodoApi.Dtos;
+namespace TodoApi.Dtos.TodoLists;
 
 public class UpdateTodoList
 {


### PR DESCRIPTION
## Summary
- Group item-related DTOs under `Dtos/TodoItems` and list-related DTOs under `Dtos/TodoLists`
- Update namespaces and using directives across controllers and tests

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68acfcb62664832888f6eb6737f6089c