### PR TITLE
Use pattern matching for entity retrieval

### DIFF
--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -30,12 +30,7 @@ public class TodoItemsController : ControllerBase
     [HttpGet("{id}")]
     public async Task<ActionResult<TodoItemDto>> GetTodoItem(long todolistId, long id)
     {
-        var todoItem = await _itemRepository.GetAsync(todolistId, id);
-
-        if (todoItem == null)
-        {
-            return NotFound();
-        }
+        if (await _itemRepository.GetAsync(todolistId, id) is not { } todoItem) return NotFound();
 
         return Ok(todoItem.ToDto());
     }
@@ -45,9 +40,7 @@ public class TodoItemsController : ControllerBase
     [HttpPut("{id}")]
     public async Task<ActionResult> PutTodoItem(long todolistId, long id, UpdateTodoItem payload)
     {
-        var todoItem = await _itemRepository.GetAsync(todolistId, id, track: true);
-        if (todoItem == null)
-            return NotFound();
+        if (await _itemRepository.GetAsync(todolistId, id, track: true) is not { } todoItem) return NotFound();
 
         payload.UpdateModel(todoItem);
 
@@ -61,9 +54,7 @@ public class TodoItemsController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<TodoItemDto>> PostTodoItem(long todolistId, CreateTodoItem payload)
     {
-        var todoList = await _listRepository.GetAsync(todolistId);
-        if (todoList == null)
-            return NotFound();
+        if (await _listRepository.GetAsync(todolistId) is not { } todoList) return NotFound();
 
         var todoItem = payload.ToModel(todolistId);
 
@@ -76,12 +67,7 @@ public class TodoItemsController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<ActionResult> DeleteTodoItem(long todolistId, long id)
     {
-        var todoItem = await _itemRepository.GetAsync(todolistId, id, track: true);
-
-        if (todoItem == null)
-        {
-            return NotFound();
-        }
+        if (await _itemRepository.GetAsync(todolistId, id, track: true) is not { } todoItem) return NotFound();
 
         await _itemRepository.RemoveAsync(todoItem);
 

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -32,12 +32,7 @@ public class TodoListsController : ControllerBase
     [HttpGet("{id}")]
     public async Task<ActionResult<TodoListDto>> GetTodoList(long id)
     {
-        var todoList = await _repository.GetAsync(id);
-
-        if (todoList == null)
-        {
-            return NotFound();
-        }
+        if (await _repository.GetAsync(id) is not { } todoList) return NotFound();
 
         return Ok(todoList.ToDto());
     }
@@ -47,12 +42,7 @@ public class TodoListsController : ControllerBase
     [HttpPut("{id}")]
     public async Task<ActionResult> PutTodoList(long id, UpdateTodoList payload)
     {
-        var todoList = await _repository.GetAsync(id, track: true);
-
-        if (todoList == null)
-        {
-            return NotFound();
-        }
+        if (await _repository.GetAsync(id, track: true) is not { } todoList) return NotFound();
 
         payload.UpdateModel(todoList);
         await _repository.SaveChangesAsync();
@@ -76,11 +66,7 @@ public class TodoListsController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<ActionResult> DeleteTodoList(long id)
     {
-        var todoList = await _repository.GetAsync(id, track: true);
-        if (todoList == null)
-        {
-            return NotFound();
-        }
+        if (await _repository.GetAsync(id, track: true) is not { } todoList) return NotFound();
 
         await _repository.RemoveAsync(todoList);
 


### PR DESCRIPTION
## Summary
- Replace null checks with C# pattern matching in TodoListsController
- Simplify entity fetches in TodoItemsController using `is not { }`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad193d2dd08328a131ad2dbcc848d6