### PR TITLE
Add summary DTO and item count projection for todo lists

### DIFF
--- a/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
@@ -37,7 +37,7 @@ public class TodoListsControllerTests
             var result = await controller.GetTodoLists();
 
             Assert.IsType<OkObjectResult>(result.Result);
-            Assert.Equal(2, ((result.Result as OkObjectResult).Value as IList<TodoListDto>).Count);
+            Assert.Equal(2, ((result.Result as OkObjectResult).Value as IList<TodoListSummaryDto>).Count);
         }
     }
 

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -13,10 +13,10 @@ public class TodoListsController(ITodoListRepository _repository) : ControllerBa
 {
     // GET: api/todolists
     [HttpGet]
-    public async Task<ActionResult<IList<TodoListDto>>> GetTodoLists()
+    public async Task<ActionResult<IList<TodoListSummaryDto>>> GetTodoLists()
     {
         var lists = await _repository.GetAllAsync();
-        var dtos = lists.Select(list => list.ToDto()).ToList();
+        var dtos = lists.Select(list => list.ToSummaryDto()).ToList();
 
         return Ok(dtos);
     }

--- a/TodoApi/Dtos/TodoLists/TodoListSummaryDto.cs
+++ b/TodoApi/Dtos/TodoLists/TodoListSummaryDto.cs
@@ -1,0 +1,12 @@
+namespace TodoApi.Dtos.TodoLists;
+
+/// <summary>
+/// Represents a lightweight view of a todo list including item count.
+/// </summary>
+public class TodoListSummaryDto
+{
+    public long Id { get; set; }
+    public required string Name { get; set; }
+    public int ItemCount { get; set; }
+}
+

--- a/TodoApi/Mappers/TodoListMapper.cs
+++ b/TodoApi/Mappers/TodoListMapper.cs
@@ -17,6 +17,16 @@ public static class TodoListMapper
         };
     }
 
+    public static TodoListSummaryDto ToSummaryDto(this TodoList list)
+    {
+        return new TodoListSummaryDto
+        {
+            Id = list.Id,
+            Name = list.Name,
+            ItemCount = list.ItemCount
+        };
+    }
+
     public static TodoList ToModel(this CreateTodoList dto)
     {
         return new TodoList

--- a/TodoApi/Models/TodoList.cs
+++ b/TodoApi/Models/TodoList.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace TodoApi.Models;
 
 public class TodoList
@@ -5,4 +7,7 @@ public class TodoList
     public long Id { get; set; }
     public required string Name { get; set; }
     public List<TodoItem> TodoItems { get; set; } = new();
+
+    [NotMapped]
+    public int ItemCount { get; set; }
 }

--- a/TodoApi/Repositories/TodoListRepository.cs
+++ b/TodoApi/Repositories/TodoListRepository.cs
@@ -7,7 +7,15 @@ public class TodoListRepository(TodoContext _context) : ITodoListRepository
 {
     public async Task<IList<TodoList>> GetAllAsync()
     {
-        return await _context.TodoList.AsNoTracking().ToListAsync();
+        return await _context.TodoList
+            .AsNoTracking()
+            .Select(l => new TodoList
+            {
+                Id = l.Id,
+                Name = l.Name,
+                ItemCount = l.TodoItems.Count
+            })
+            .ToListAsync();
     }
 
     public Task<TodoList?> GetAsync(long id, bool track = false)


### PR DESCRIPTION
## Summary
- add non-mapped ItemCount to TodoList model
- introduce TodoListSummaryDto with XML doc comment
- project item counts in repository and expose summary DTO via controller and mappers

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1eb5a7608328b4ddca32bef3c3e2