### PR TITLE
Add pagination and search to Todo API endpoints

### DIFF
--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -11,9 +11,13 @@ public class TodoItemsController(ITodoItemRepository _itemRepository, ITodoListR
 {
     // GET: api/todolist/{id}/todoitems
     [HttpGet]
-    public async Task<ActionResult<IList<TodoItemDto>>> GetTodoItems(long todolistId)
+    public async Task<ActionResult<IList<TodoItemDto>>> GetTodoItems(
+        long todolistId,
+        [FromQuery] string? search = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
-        var items = await _itemRepository.GetByListIdAsync(todolistId);
+        var items = await _itemRepository.GetByListIdAsync(todolistId, search, page, pageSize);
         return Ok(items.Select(item => item.ToDto()).ToList());
     }
 

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -11,9 +11,13 @@ public class TodoListsController(ITodoListRepository _repository) : ControllerBa
 {
     // GET: api/todolists
     [HttpGet]
-    public async Task<ActionResult<IList<TodoListDto>>> GetTodoLists([FromQuery] bool includeItems = false)
+    public async Task<ActionResult<IList<TodoListDto>>> GetTodoLists(
+        [FromQuery] bool includeItems = false,
+        [FromQuery] string? search = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 10)
     {
-        var lists = await _repository.GetAllAsync(includeItems);
+        var lists = await _repository.GetAllAsync(includeItems, search, page, pageSize);
         var dtos = lists.Select(list => list.ToDto(includeItems)).ToList();
 
         return Ok(dtos);

--- a/TodoApi/Repositories/ITodoItemRepository.cs
+++ b/TodoApi/Repositories/ITodoItemRepository.cs
@@ -4,7 +4,11 @@ namespace TodoApi.Repositories;
 
 public interface ITodoItemRepository
 {
-    Task<IList<TodoItem>> GetByListIdAsync(long listId);
+    Task<IList<TodoItem>> GetByListIdAsync(
+        long listId,
+        string? search = null,
+        int page = 1,
+        int pageSize = 10);
     Task<TodoItem?> GetAsync(long listId, long id, bool track = false);
     Task AddAsync(TodoItem item);
     Task RemoveAsync(TodoItem item);

--- a/TodoApi/Repositories/ITodoListRepository.cs
+++ b/TodoApi/Repositories/ITodoListRepository.cs
@@ -4,7 +4,11 @@ namespace TodoApi.Repositories;
 
 public interface ITodoListRepository
 {
-    Task<IList<TodoList>> GetAllAsync(bool includeItems = false);
+    Task<IList<TodoList>> GetAllAsync(
+        bool includeItems = false,
+        string? search = null,
+        int page = 1,
+        int pageSize = 10);
     Task<TodoList?> GetAsync(long id, bool track = false);
     Task AddAsync(TodoList list);
     Task RemoveAsync(TodoList list);

--- a/TodoApi/Repositories/TodoItemRepository.cs
+++ b/TodoApi/Repositories/TodoItemRepository.cs
@@ -5,11 +5,23 @@ namespace TodoApi.Repositories;
 
 public class TodoItemRepository(TodoContext _context) : ITodoItemRepository
 {
-    public async Task<IList<TodoItem>> GetByListIdAsync(long listId)
+    public async Task<IList<TodoItem>> GetByListIdAsync(
+        long listId,
+        string? search = null,
+        int page = 1,
+        int pageSize = 10)
     {
-        return await _context.TodoItems
+        var query = _context.TodoItems
             .Where(i => i.TodoListId == listId)
-            .AsNoTracking()
+            .AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(search))
+            query = query.Where(i => EF.Functions.Like(i.Description, $"%{search}%"));
+
+        return await query
+            .OrderBy(i => i.Id)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .ToListAsync();
     }
 


### PR DESCRIPTION
## Summary
- add search and pagination to todo list and item endpoints
- implement filtering/paging in repositories
- expand controller tests for search and pagination

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc1a04c3c832891de2a9a2c0b0a47