### PR TITLE
Search item descriptions when listing todo lists

### DIFF
--- a/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
@@ -93,6 +93,29 @@ public class TodoListsControllerTests
     }
 
     [Fact]
+    public async Task GetTodoLists_WhenSearchedByItemDescription_ReturnsParentList()
+    {
+        using (var context = new TodoContext(DatabaseContextOptions()))
+        {
+            PopulateDatabaseContext(context);
+
+            var list = new TodoList { Id = 3, Name = "Groceries" };
+            context.TodoList.Add(list);
+            context.TodoItems.Add(new TodoItem { Id = 1, TodoListId = 3, Description = "Buy milk" });
+            context.SaveChanges();
+
+            var repository = new TodoListRepository(context);
+            var controller = new TodoListsController(repository);
+
+            var result = await controller.GetTodoLists(search: "milk");
+
+            var ok = Assert.IsType<OkObjectResult>(result.Result);
+            var lists = Assert.IsAssignableFrom<IList<TodoListDto>>(ok.Value);
+            Assert.Collection(lists, l => Assert.Equal("Groceries", l.Name));
+        }
+    }
+
+    [Fact]
     public async Task GetTodoLists_WhenPaginated_ReturnsCorrectPage()
     {
         using (var context = new TodoContext(DatabaseContextOptions()))

--- a/TodoApi/Repositories/ITodoListRepository.cs
+++ b/TodoApi/Repositories/ITodoListRepository.cs
@@ -4,6 +4,13 @@ namespace TodoApi.Repositories;
 
 public interface ITodoListRepository
 {
+    /// <summary>
+    /// Retrieves todo lists with optional filtering and pagination.
+    /// </summary>
+    /// <param name="includeItems">Whether to include list items in the result.</param>
+    /// <param name="search">Optional term to search by list name or item description.</param>
+    /// <param name="page">The 1-based page index.</param>
+    /// <param name="pageSize">The number of records per page.</param>
     Task<IList<TodoList>> GetAllAsync(
         bool includeItems = false,
         string? search = null,

--- a/TodoApi/Repositories/TodoListRepository.cs
+++ b/TodoApi/Repositories/TodoListRepository.cs
@@ -15,7 +15,9 @@ public class TodoListRepository(TodoContext _context) : ITodoListRepository
         var query = _context.TodoList.AsNoTracking();
 
         if (!string.IsNullOrWhiteSpace(search))
-            query = query.Where(l => EF.Functions.Like(l.Name, $"%{search}%"));
+            query = query.Where(l =>
+                EF.Functions.Like(l.Name, $"%{search}%") ||
+                l.TodoItems.Any(i => EF.Functions.Like(i.Description, $"%{search}%")));
 
         if (includeItems)
             query = query.Include(l => l.TodoItems);


### PR DESCRIPTION
## Summary
- allow searching todo lists by item description in TodoListRepository
- document search parameter behavior in ITodoListRepository
- add controller test ensuring search returns list when item description matches

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adc54596c48328b6c0cf1617bf638d