### PR TITLE
Add Swagger and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ To run the TodoApi in your local environment:
 
 `dotnet run --project TodoApi`
 
+## API Documentation
+
+The API exposes a Swagger UI for interactive documentation. Once the application is running, navigate to `/swagger` to explore and test endpoints.
+
 ## Test
 
 To run tests:

--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TodoApi.Dtos.TodoItems;
@@ -26,6 +27,7 @@ public class TodoItemsController(
     /// <param name="pageSize">The number of items per page.</param>
     /// <returns>A list of todo items.</returns>
     [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200Ok, Type = typeof(IEnumerable<TodoItemDto>))]
     public async Task<ActionResult<IList<TodoItemDto>>> GetTodoItems(
         long todolistId,
         [FromQuery] string? search = null,
@@ -43,7 +45,11 @@ public class TodoItemsController(
     /// <param name="todolistId">The identifier of the todo list.</param>
     /// <param name="id">The identifier of the todo item.</param>
     /// <returns>The requested todo item.</returns>
+    /// <response code="200">The requested todo item.</response>
+    /// <response code="404">The todo item was not found.</response>
     [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200Ok, Type = typeof(TodoItemDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TodoItemDto>> GetTodoItem(long todolistId, long id)
     {
         if (await _itemRepository.GetAsync(todolistId, id) is not { } todoItem)
@@ -62,7 +68,11 @@ public class TodoItemsController(
     /// <param name="id">The identifier of the todo item.</param>
     /// <param name="payload">Updated fields for the todo item.</param>
     /// <returns>No content on success.</returns>
+    /// <response code="204">The todo item was updated successfully.</response>
+    /// <response code="404">The todo item was not found.</response>
     [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> PutTodoItem(long todolistId, long id, UpdateTodoItem payload)
     {
         if (await _itemRepository.GetAsync(todolistId, id, track: true) is not { } todoItem)
@@ -85,7 +95,11 @@ public class TodoItemsController(
     /// <param name="todolistId">The identifier of the todo list.</param>
     /// <param name="payload">Data for the new todo item.</param>
     /// <returns>The created todo item.</returns>
+    /// <response code="201">The todo item was created successfully.</response>
+    /// <response code="404">The parent todo list was not found.</response>
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(TodoItemDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TodoItemDto>> PostTodoItem(long todolistId, CreateTodoItem payload)
     {
         if (await _listRepository.GetAsync(todolistId) is not { } todoList)
@@ -108,7 +122,11 @@ public class TodoItemsController(
     /// <param name="todolistId">The identifier of the todo list.</param>
     /// <param name="id">The identifier of the todo item.</param>
     /// <returns>No content on success.</returns>
+    /// <response code="204">The todo item was deleted.</response>
+    /// <response code="404">The todo item was not found.</response>
     [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteTodoItem(long todolistId, long id)
     {
         if (await _itemRepository.GetAsync(todolistId, id, track: true) is not { } todoItem)

--- a/TodoApi/Controllers/TodoItemsController.cs
+++ b/TodoApi/Controllers/TodoItemsController.cs
@@ -6,6 +6,9 @@ using TodoApi.Repositories;
 
 namespace TodoApi.Controllers;
 
+/// <summary>
+/// API for managing todo items within a todo list.
+/// </summary>
 [Route("api/todolist/{todolistId}/todoitems")]
 [ApiController]
 public class TodoItemsController(
@@ -14,7 +17,14 @@ public class TodoItemsController(
     ILogger<TodoItemsController> _logger
 ) : ControllerBase
 {
-    // GET: api/todolist/{id}/todoitems
+    /// <summary>
+    /// Retrieves items for the specified todo list.
+    /// </summary>
+    /// <param name="todolistId">The identifier of the todo list.</param>
+    /// <param name="search">Optional search term to filter items.</param>
+    /// <param name="page">The page number for pagination.</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    /// <returns>A list of todo items.</returns>
     [HttpGet]
     public async Task<ActionResult<IList<TodoItemDto>>> GetTodoItems(
         long todolistId,
@@ -27,7 +37,12 @@ public class TodoItemsController(
         return Ok(items.Select(item => item.ToDto()).ToList());
     }
 
-    // GET: api/todolist/{id}/todoitems/5
+    /// <summary>
+    /// Retrieves a specific todo item from the specified list.
+    /// </summary>
+    /// <param name="todolistId">The identifier of the todo list.</param>
+    /// <param name="id">The identifier of the todo item.</param>
+    /// <returns>The requested todo item.</returns>
     [HttpGet("{id}")]
     public async Task<ActionResult<TodoItemDto>> GetTodoItem(long todolistId, long id)
     {
@@ -40,8 +55,13 @@ public class TodoItemsController(
         return Ok(todoItem.ToDto());
     }
 
-    // PUT: api/todoitems/5
-    // To protect from over-posting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+    /// <summary>
+    /// Updates a todo item in the specified list.
+    /// </summary>
+    /// <param name="todolistId">The identifier of the todo list.</param>
+    /// <param name="id">The identifier of the todo item.</param>
+    /// <param name="payload">Updated fields for the todo item.</param>
+    /// <returns>No content on success.</returns>
     [HttpPut("{id}")]
     public async Task<ActionResult> PutTodoItem(long todolistId, long id, UpdateTodoItem payload)
     {
@@ -59,8 +79,12 @@ public class TodoItemsController(
         return NoContent();
     }
 
-    // POST: api/todoitems
-    // To protect from over-posting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+    /// <summary>
+    /// Creates a new todo item in the specified list.
+    /// </summary>
+    /// <param name="todolistId">The identifier of the todo list.</param>
+    /// <param name="payload">Data for the new todo item.</param>
+    /// <returns>The created todo item.</returns>
     [HttpPost]
     public async Task<ActionResult<TodoItemDto>> PostTodoItem(long todolistId, CreateTodoItem payload)
     {
@@ -78,7 +102,12 @@ public class TodoItemsController(
         return CreatedAtAction(nameof(GetTodoItem), new { todolistId, id = todoItem.Id }, todoItem.ToDto());
     }
 
-    // DELETE: api/todolist/{todolistId}/todoitems/{id}
+    /// <summary>
+    /// Deletes a todo item from the specified list.
+    /// </summary>
+    /// <param name="todolistId">The identifier of the todo list.</param>
+    /// <param name="id">The identifier of the todo item.</param>
+    /// <returns>No content on success.</returns>
     [HttpDelete("{id}")]
     public async Task<ActionResult> DeleteTodoItem(long todolistId, long id)
     {

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using TodoApi.Dtos.TodoLists;
@@ -25,6 +26,7 @@ public class TodoListsController(
     /// <param name="pageSize">The number of items per page.</param>
     /// <returns>A list of todo lists.</returns>
     [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200Ok, Type = typeof(IEnumerable<TodoListDto>))]
     public async Task<ActionResult<IList<TodoListDto>>> GetTodoLists(
         [FromQuery] bool includeItems = false,
         [FromQuery] string? search = null,
@@ -43,7 +45,11 @@ public class TodoListsController(
     /// </summary>
     /// <param name="id">The identifier of the todo list.</param>
     /// <returns>The requested todo list.</returns>
+    /// <response code="200">The requested todo list.</response>
+    /// <response code="404">The todo list was not found.</response>
     [HttpGet("{id}")]
+    [ProducesResponseType(StatusCodes.Status200Ok, Type = typeof(TodoListDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TodoListDto>> GetTodoList(long id)
     {
         if (await _repository.GetAsync(id) is not { } todoList)
@@ -61,7 +67,11 @@ public class TodoListsController(
     /// <param name="id">The identifier of the todo list.</param>
     /// <param name="payload">Updated fields for the todo list.</param>
     /// <returns>The updated todo list.</returns>
+    /// <response code="200">The todo list was updated successfully.</response>
+    /// <response code="404">The todo list was not found.</response>
     [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status200Ok, Type = typeof(TodoListDto))]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> PutTodoList(long id, UpdateTodoList payload)
     {
         if (await _repository.GetAsync(id, track: true) is not { } todoList)
@@ -82,7 +92,9 @@ public class TodoListsController(
     /// </summary>
     /// <param name="payload">Data for the new list.</param>
     /// <returns>The created todo list.</returns>
+    /// <response code="201">The todo list was created successfully.</response>
     [HttpPost]
+    [ProducesResponseType(StatusCodes.Status201Created, Type = typeof(TodoListDto))]
     public async Task<ActionResult<TodoListDto>> PostTodoList(CreateTodoList payload)
     {
         var todoList = payload.ToModel();
@@ -98,7 +110,11 @@ public class TodoListsController(
     /// </summary>
     /// <param name="id">The identifier of the todo list.</param>
     /// <returns>No content on success.</returns>
+    /// <response code="204">The todo list was deleted.</response>
+    /// <response code="404">The todo list was not found.</response>
     [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteTodoList(long id)
     {
         if (await _repository.GetAsync(id, track: true) is not { } todoList)

--- a/TodoApi/Controllers/TodoListsController.cs
+++ b/TodoApi/Controllers/TodoListsController.cs
@@ -6,6 +6,9 @@ using TodoApi.Repositories;
 
 namespace TodoApi.Controllers;
 
+/// <summary>
+/// API for managing todo lists.
+/// </summary>
 [Route("api/todolists")]
 [ApiController]
 public class TodoListsController(
@@ -13,7 +16,14 @@ public class TodoListsController(
     ILogger<TodoListsController> _logger
 ) : ControllerBase
 {
-    // GET: api/todolists
+    /// <summary>
+    /// Retrieves todo lists with optional pagination and search.
+    /// </summary>
+    /// <param name="includeItems">Whether to include todo items in the response.</param>
+    /// <param name="search">Optional search term to filter lists.</param>
+    /// <param name="page">The page number for pagination.</param>
+    /// <param name="pageSize">The number of items per page.</param>
+    /// <returns>A list of todo lists.</returns>
     [HttpGet]
     public async Task<ActionResult<IList<TodoListDto>>> GetTodoLists(
         [FromQuery] bool includeItems = false,
@@ -28,7 +38,11 @@ public class TodoListsController(
         return Ok(dtos);
     }
 
-    // GET: api/todolists/5
+    /// <summary>
+    /// Retrieves a specific todo list.
+    /// </summary>
+    /// <param name="id">The identifier of the todo list.</param>
+    /// <returns>The requested todo list.</returns>
     [HttpGet("{id}")]
     public async Task<ActionResult<TodoListDto>> GetTodoList(long id)
     {
@@ -41,8 +55,12 @@ public class TodoListsController(
         return Ok(todoList.ToDto());
     }
 
-    // PUT: api/todolists/5
-    // To protect from over-posting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+    /// <summary>
+    /// Updates a todo list.
+    /// </summary>
+    /// <param name="id">The identifier of the todo list.</param>
+    /// <param name="payload">Updated fields for the todo list.</param>
+    /// <returns>The updated todo list.</returns>
     [HttpPut("{id}")]
     public async Task<ActionResult> PutTodoList(long id, UpdateTodoList payload)
     {
@@ -59,8 +77,11 @@ public class TodoListsController(
         return Ok(todoList.ToDto());
     }
 
-    // POST: api/todolists
-    // To protect from over-posting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
+    /// <summary>
+    /// Creates a new todo list.
+    /// </summary>
+    /// <param name="payload">Data for the new list.</param>
+    /// <returns>The created todo list.</returns>
     [HttpPost]
     public async Task<ActionResult<TodoListDto>> PostTodoList(CreateTodoList payload)
     {
@@ -72,7 +93,11 @@ public class TodoListsController(
         return CreatedAtAction(nameof(GetTodoList), new { id = todoList.Id }, todoList.ToDto());
     }
 
-    // DELETE: api/todolists/5
+    /// <summary>
+    /// Deletes a todo list.
+    /// </summary>
+    /// <param name="id">The identifier of the todo list.</param>
+    /// <returns>No content on success.</returns>
     [HttpDelete("{id}")]
     public async Task<ActionResult> DeleteTodoList(long id)
     {

--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using TodoApi.Repositories;
 using TodoApi.Middleware;
+using System.Reflection;
+using System.IO;
 
 var builder = WebApplication.CreateBuilder(args);
 builder
@@ -8,6 +10,12 @@ builder
         opt.UseSqlServer(builder.Configuration.GetConnectionString("TodoContext"))
     )
     .AddEndpointsApiExplorer()
+    .AddSwaggerGen(c =>
+    {
+        var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+        var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+        c.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
+    })
     .AddControllers();
 
 builder.Services.AddScoped<ITodoListRepository, TodoListRepository>();
@@ -19,6 +27,9 @@ builder.Logging.AddConsole();
 var app = builder.Build();
 
 app.UseMiddleware<ErrorHandlingMiddleware>();
+
+app.UseSwagger();
+app.UseSwaggerUI();
 
 app.UseAuthorization();
 app.MapControllers();

--- a/TodoApi/TodoApi.csproj
+++ b/TodoApi/TodoApi.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -14,6 +16,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0-*" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0-*" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Configure Swagger generation and UI with XML comments
- Enable XML documentation and add summary comments for controllers
- Document parameters and return types for todo item and list endpoints
- Document Swagger endpoint in README

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcb110ee48328bed3b49875452601