### PR TITLE
Add logger dependencies to controller tests

### DIFF
--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using TodoApi.Controllers;
 using TodoApi.Models;
 using TodoApi.Repositories;
@@ -26,6 +27,13 @@ public class TodoItemsControllerTests
         context.SaveChanges();
     }
 
+    private TodoItemsController CreateController(TodoContext context)
+    {
+        var itemRepository = new TodoItemRepository(context);
+        var listRepository = new TodoListRepository(context);
+        return new TodoItemsController(itemRepository, listRepository, NullLogger<TodoItemsController>.Instance);
+    }
+
     [Fact]
     public async Task DeleteTodoItem_WhenItemBelongsToList_RemovesItem()
     {
@@ -33,9 +41,7 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var result = await controller.DeleteTodoItem(1, 1);
 
@@ -51,9 +57,7 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var result = await controller.DeleteTodoItem(1, 2);
 
@@ -69,9 +73,7 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var payload = new UpdateTodoItem { IsCompleted = true };
 
@@ -92,9 +94,7 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoItems(1);
 
@@ -111,9 +111,7 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoItem(1, 1);
 
@@ -130,9 +128,7 @@ public class TodoItemsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var payload = new CreateTodoItem { Description = "Item 3", IsCompleted = false };
 
@@ -154,9 +150,7 @@ public class TodoItemsControllerTests
             context.TodoItems.Add(new TodoItem { Id = 3, TodoListId = 1, Description = "Home task", IsCompleted = false });
             context.SaveChanges();
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoItems(1, search: "Home");
 
@@ -178,9 +172,7 @@ public class TodoItemsControllerTests
             context.TodoItems.Add(new TodoItem { Id = 5, TodoListId = 1, Description = "Item 5", IsCompleted = false });
             context.SaveChanges();
 
-            var itemRepository = new TodoItemRepository(context);
-            var listRepository = new TodoListRepository(context);
-            var controller = new TodoItemsController(itemRepository, listRepository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoItems(1, page: 2, pageSize: 2);
 

--- a/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoListsControllerTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
 using TodoApi.Controllers;
 using TodoApi.Models;
 using TodoApi.Repositories;
@@ -24,6 +25,12 @@ public class TodoListsControllerTests
         context.SaveChanges();
     }
 
+    private TodoListsController CreateController(TodoContext context)
+    {
+        var repository = new TodoListRepository(context);
+        return new TodoListsController(repository, NullLogger<TodoListsController>.Instance);
+    }
+
     [Fact]
     public async Task GetTodoList_WhenCalled_ReturnsTodoListList()
     {
@@ -31,8 +38,7 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoLists();
 
@@ -57,8 +63,7 @@ public class TodoListsControllerTests
             context.TodoItems.Add(new TodoItem { Id = 1, TodoListId = 1, Description = "Item 1", IsCompleted = false });
             context.SaveChanges();
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoLists(true);
 
@@ -81,8 +86,7 @@ public class TodoListsControllerTests
             context.TodoList.Add(new TodoList { Id = 4, Name = "Shopping" });
             context.SaveChanges();
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoLists(search: "Shop");
 
@@ -104,8 +108,7 @@ public class TodoListsControllerTests
             context.TodoItems.Add(new TodoItem { Id = 1, TodoListId = 3, Description = "Buy milk" });
             context.SaveChanges();
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoLists(search: "milk");
 
@@ -127,8 +130,7 @@ public class TodoListsControllerTests
             context.TodoList.Add(new TodoList { Id = 5, Name = "Task 5" });
             context.SaveChanges();
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoLists(page: 2, pageSize: 2);
 
@@ -148,8 +150,7 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.GetTodoList(1);
 
@@ -165,8 +166,7 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.PutTodoList(
                 3,
@@ -184,8 +184,7 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var todoList = await context.TodoList.Where(x => x.Id == 2).FirstAsync();
             var result = await controller.PutTodoList(
@@ -204,8 +203,7 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.PostTodoList(new CreateTodoList { Name = "Task 3" });
 
@@ -221,8 +219,7 @@ public class TodoListsControllerTests
         {
             PopulateDatabaseContext(context);
 
-            var repository = new TodoListRepository(context);
-            var controller = new TodoListsController(repository);
+            var controller = CreateController(context);
 
             var result = await controller.DeleteTodoList(2);
 


### PR DESCRIPTION
## Summary
- inject NullLogger into `TodoItemsController` tests
- inject NullLogger into `TodoListsController` tests
- centralize controller construction in tests via helper methods

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adde145fec832897368c2b6bd0bd72