### PR TITLE
Add validation messages and DTO tests

### DIFF
--- a/TodoApi.Tests/Dtos/DtoValidationTests.cs
+++ b/TodoApi.Tests/Dtos/DtoValidationTests.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+using TodoApi.Dtos.TodoItems;
+using TodoApi.Dtos.TodoLists;
+
+namespace TodoApi.Tests.Dtos;
+
+public class DtoValidationTests
+{
+    [Fact]
+    public void CreateTodoItem_MissingDescription_ReturnsRequiredMessage()
+    {
+        var dto = new CreateTodoItem();
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, new ValidationContext(dto), results, true);
+
+        Assert.False(isValid);
+        var error = Assert.Single(results);
+        Assert.Equal("Description is required.", error.ErrorMessage);
+    }
+
+    [Fact]
+    public void CreateTodoList_MissingName_ReturnsRequiredMessage()
+    {
+        var dto = new CreateTodoList();
+        var results = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(dto, new ValidationContext(dto), results, true);
+
+        Assert.False(isValid);
+        var error = Assert.Single(results);
+        Assert.Equal("Name is required.", error.ErrorMessage);
+    }
+}

--- a/TodoApi/Dtos/TodoItems/CreateTodoItem.cs
+++ b/TodoApi/Dtos/TodoItems/CreateTodoItem.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TodoApi.Dtos.TodoItems;
 
 public class CreateTodoItem
 {
-    public required string Description { get; set; }
+    [Required(ErrorMessage = "Description is required.")]
+    public string Description { get; set; } = null!;
     public bool IsCompleted { get; set; }
 }

--- a/TodoApi/Dtos/TodoLists/CreateTodoList.cs
+++ b/TodoApi/Dtos/TodoLists/CreateTodoList.cs
@@ -1,6 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TodoApi.Dtos.TodoLists;
 
 public class CreateTodoList
 {
-    public required string Name { get; set; }
+    [Required(ErrorMessage = "Name is required.")]
+    public string Name { get; set; } = null!;
 }

--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -3,6 +3,7 @@ using TodoApi.Repositories;
 using TodoApi.Middleware;
 using System.Reflection;
 using System.IO;
+using Microsoft.AspNetCore.Mvc;
 
 var builder = WebApplication.CreateBuilder(args);
 builder
@@ -16,7 +17,19 @@ builder
         var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
         c.IncludeXmlComments(xmlPath, includeControllerXmlComments: true);
     })
-    .AddControllers();
+    .AddControllers()
+    .ConfigureApiBehaviorOptions(options =>
+    {
+        options.InvalidModelStateResponseFactory = context =>
+        {
+            if (context.ModelState.ErrorCount == 0)
+            {
+                return new BadRequestObjectResult("Request body is required.");
+            }
+
+            return new BadRequestObjectResult(new ValidationProblemDetails(context.ModelState));
+        };
+    });
 
 builder.Services.AddScoped<ITodoListRepository, TodoListRepository>();
 builder.Services.AddScoped<ITodoItemRepository, TodoItemRepository>();


### PR DESCRIPTION
## Summary
- enforce description and name with `[Required]` in todo item and list DTOs
- return clearer message when request body is missing
- test DTO validation for required fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade76649588328a181aa7205e0d7dd