### PR TITLE
Validate list id when fetching todo items

### DIFF
--- a/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
+++ b/TodoApi.Tests/Controllers/TodoItemsControllerTests.cs
@@ -30,8 +30,7 @@ public class TodoItemsControllerTests
     private TodoItemsController CreateController(TodoContext context)
     {
         var itemRepository = new TodoItemRepository(context);
-        var listRepository = new TodoListRepository(context);
-        return new TodoItemsController(itemRepository, listRepository, NullLogger<TodoItemsController>.Instance);
+        return new TodoItemsController(itemRepository, NullLogger<TodoItemsController>.Instance);
     }
 
     [Fact]

--- a/TodoApi.Tests/Filters/ValidateTodoListExistsAttributeTests.cs
+++ b/TodoApi.Tests/Filters/ValidateTodoListExistsAttributeTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using TodoApi.Filters;
+using TodoApi.Models;
+using TodoApi.Repositories;
+
+namespace TodoApi.Tests.Filters;
+
+public class ValidateTodoListExistsAttributeTests
+{
+    private DbContextOptions<TodoContext> Options()
+        => new DbContextOptionsBuilder<TodoContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+    [Fact]
+    public async Task OnActionExecutionAsync_ListMissing_SetsNotFoundResult()
+    {
+        using var context = new TodoContext(Options());
+        var repository = new TodoListRepository(context);
+        var filter = new ValidateTodoListExistsAttribute(repository, NullLogger<ValidateTodoListExistsAttribute>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var executingContext = new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object> { { "todolistId", 42L } },
+            controller: null
+        );
+
+        await filter.OnActionExecutionAsync(executingContext, () => Task.FromResult<ActionExecutedContext>(null!));
+
+        Assert.IsType<NotFoundResult>(executingContext.Result);
+    }
+
+    [Fact]
+    public async Task OnActionExecutionAsync_ListExists_InvokesNext()
+    {
+        using var context = new TodoContext(Options());
+        context.TodoList.Add(new TodoList { Id = 1, Name = "List" });
+        context.SaveChanges();
+
+        var repository = new TodoListRepository(context);
+        var filter = new ValidateTodoListExistsAttribute(repository, NullLogger<ValidateTodoListExistsAttribute>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        var actionContext = new ActionContext(httpContext, new RouteData(), new ActionDescriptor());
+        var executingContext = new ActionExecutingContext(
+            actionContext,
+            new List<IFilterMetadata>(),
+            new Dictionary<string, object> { { "todolistId", 1L } },
+            controller: null
+        );
+
+        var called = false;
+        await filter.OnActionExecutionAsync(executingContext, () =>
+        {
+            called = true;
+            return Task.FromResult(new ActionExecutedContext(actionContext, new List<IFilterMetadata>(), controller: null));
+        });
+
+        Assert.True(called);
+        Assert.Null(executingContext.Result);
+    }
+}

--- a/TodoApi/Filters/ValidateTodoListExistsAttribute.cs
+++ b/TodoApi/Filters/ValidateTodoListExistsAttribute.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TodoApi.Repositories;
+
+namespace TodoApi.Filters;
+
+/// <summary>
+/// Ensures the requested todo list exists before executing the action.
+/// </summary>
+public class ValidateTodoListExistsAttribute(
+    ITodoListRepository _repository,
+    ILogger<ValidateTodoListExistsAttribute> _logger
+) : ActionFilterAttribute
+{
+    public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        if (context.ActionArguments.TryGetValue("todolistId", out var value) && value is long listId)
+        {
+            if (await _repository.GetAsync(listId, cancellationToken: context.HttpContext.RequestAborted) is null)
+            {
+                _logger.LogWarning("Todo list {ListId} not found", listId);
+                context.Result = new NotFoundResult();
+                return;
+            }
+        }
+
+        await next();
+    }
+}

--- a/TodoApi/Program.cs
+++ b/TodoApi/Program.cs
@@ -3,6 +3,7 @@ using TodoApi.Repositories;
 using TodoApi.Middleware;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc;
+using TodoApi.Filters;
 
 var builder = WebApplication.CreateBuilder(args);
 builder
@@ -32,6 +33,7 @@ builder
 
 builder.Services.AddScoped<ITodoListRepository, TodoListRepository>();
 builder.Services.AddScoped<ITodoItemRepository, TodoItemRepository>();
+builder.Services.AddScoped<ValidateTodoListExistsAttribute>();
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();


### PR DESCRIPTION
## Summary
- add action filter to ensure todo list exists before item operations
- remove in-method list checks and register filter
- add unit tests for the new filter

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ae26e5b9dc8328ae61acc67572aaaf